### PR TITLE
Build contributing page script

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -44,7 +44,9 @@ jobs:
         else echo "Skipping patching, as this is the FINOS Organization"
         fi
     - name: Build Website
-      run: npm run build --prefix website
+      run: |
+        ./build-contribute-page.sh
+        npm run build --prefix website
     - name: Publish Website
       run: |
         # Extract GitHub org/user

--- a/build-contribute-page.sh
+++ b/build-contribute-page.sh
@@ -1,0 +1,7 @@
+CONTRIBUTING_PATH=docs/contributing.md
+ls
+cp ./.github/CONTRIBUTING.md $CONTRIBUTING_PATH
+echo '---
+id: contributing
+title: Contributing
+---' | cat - $CONTRIBUTING_PATH > temp && mv temp $CONTRIBUTING_PATH

--- a/build-contribute-page.sh
+++ b/build-contribute-page.sh
@@ -1,5 +1,4 @@
 CONTRIBUTING_PATH=docs/contributing.md
-ls
 cp ./.github/CONTRIBUTING.md $CONTRIBUTING_PATH
 echo '---
 id: contributing

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,8 +2,7 @@
   "docs": {
     "Docusaurus": ["notes-2018-07-25"],
     "First Category": ["notes-2018-07-25"],
-    "Second Category": ["notes-2018-07-25"],
-    { href: 'https://www.finos.org/privacy-policy', label: 'FINOS Privacy Policy' }
+    "Second Category": ["notes-2018-07-25"]
   },
   "docs-other": {
     "First Category": ["notes-2018-07-25", "notes-2018-07-25"]


### PR DESCRIPTION
Issue [FINOS Project Blueprint Docusaurus content to include .github/CONTRIBUTING.md](https://github.com/finos/open-developer-platform/issues/67)

I created a script as @maoo  suggested. In his [implementation](https://github.com/finos/alloy/blob/master/build-site.sh#L21-L35) he added the script only to docusaurus.yml so I did the same. But for testing locally I try this in package.json
`"build": "cd .. && bash build-contribute-page.sh && cd ./website && docusaurus-build"`

Also I had to modify sidebars.json beacause it has an error and was breaking the build.


This is the end result:
![image](https://user-images.githubusercontent.com/47067313/75896806-62512d00-5e16-11ea-88ef-2b8d2deca4fa.png)
