### PR TITLE
Update WhiteSource Docusaurus Excludes and Update ODP Documentation URL

### DIFF
--- a/whitesource.config
+++ b/whitesource.config
@@ -1,7 +1,7 @@
 ###############################################################
 # WhiteSource custom configuration file
 # To enable WS integration on a FINOS repo, email help@finos.org
-# Please read docs on https://finosfoundation.atlassian.net/wiki/spaces/FDX/pages/1129283585/WhiteSource+for+GitHub.com
+# Please read docs on # Please read docs on https://odp.finos.org/docs/development-infrastructure/code-validation/whitesource
 ###############################################################
 
 # FINOS updated properties
@@ -9,7 +9,7 @@
 npm.includeDevDependencies=false
 npm.runPreStep=true
 log.Level=debug
-excludes=**/*sources.jar **/*javadoc.jar
+excludes=**/*sources.jar **/*javadoc.jar **/website/node_modules/**
 ###############################################################
 
 # GENERAL SCAN MODE: Files and Package Managers

--- a/whitesource.config
+++ b/whitesource.config
@@ -1,7 +1,7 @@
 ###############################################################
 # WhiteSource custom configuration file
 # To enable WS integration on a FINOS repo, email help@finos.org
-# Please read docs on # Please read docs on https://odp.finos.org/docs/development-infrastructure/code-validation/whitesource
+# Please read docs on https://odp.finos.org/docs/development-infrastructure/code-validation/whitesource
 ###############################################################
 
 # FINOS updated properties


### PR DESCRIPTION
## Description

This PR adds Docusaurus exclude `**/website/node_modules/**` to `.whitesource.config` and updates the ODP documentation URL to https://odp.finos.org/docs/development-infrastructure/code-validation/whitesource